### PR TITLE
Refactor propagating ancestry changes

### DIFF
--- a/ancestry-inline-simplification/src/error.rs
+++ b/ancestry-inline-simplification/src/error.rs
@@ -19,4 +19,6 @@ pub enum InlineAncestryError {
         parent: LargeSignedInteger,
         child: LargeSignedInteger,
     },
+    #[error("unexpected dead node")]
+    DeadNode,
 }

--- a/ancestry-inline-simplification/src/lib.rs
+++ b/ancestry-inline-simplification/src/lib.rs
@@ -4,6 +4,7 @@ mod ancestry_overlapper;
 mod error;
 mod flags;
 mod node_heap;
+mod propagate_ancestry_changes;
 mod segments;
 mod update_ancestry;
 mod util;
@@ -15,6 +16,9 @@ pub mod node;
 pub mod population;
 
 // Public API
+// NOTE: this API is TBD, and may later
+// be exported via a pub mod.
 pub use error::InlineAncestryError;
 pub use flags::NodeFlags;
+pub use node_heap::NodeHeap;
 pub use population::Population;

--- a/ancestry-inline-simplification/src/node_heap.rs
+++ b/ancestry-inline-simplification/src/node_heap.rs
@@ -1,19 +1,32 @@
 use crate::node::Node;
+use crate::InlineAncestryError;
 use hashbrown::HashSet;
 use std::collections::BinaryHeap;
 
-#[repr(transparent)]
-struct PrioritizedNode(Node);
+#[derive(PartialEq, PartialOrd, Ord, Eq, Debug, Clone, Copy)]
+enum NodeType {
+    Parent,
+    Birth,
+    Death,
+}
+
+pub(crate) struct PrioritizedNode {
+    node: Node,
+    node_type: NodeType,
+}
 
 impl PartialEq for PrioritizedNode {
     fn eq(&self, other: &Self) -> bool {
-        std::ptr::eq(self.0.as_ptr(), other.0.as_ptr())
+        std::ptr::eq(self.node.as_ptr(), other.node.as_ptr())
     }
 }
 
 impl PartialOrd for PrioritizedNode {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.0.borrow().birth_time.cmp(&other.0.borrow().birth_time))
+        Some(
+            (self.node.borrow().birth_time, self.node_type)
+                .cmp(&(other.node.borrow().birth_time, other.node_type)),
+        )
     }
 }
 
@@ -26,48 +39,107 @@ impl Ord for PrioritizedNode {
 }
 
 impl PrioritizedNode {
+    fn new(node: Node, node_type: NodeType) -> Self {
+        Self { node, node_type }
+    }
+
     fn get(self) -> Node {
-        self.0
+        self.node
+    }
+
+    fn is_death(&self) -> bool {
+        matches!(self.node_type, NodeType::Death)
+    }
+
+    pub fn preprocess(&mut self, genome_length: crate::LargeSignedInteger) {
+        if self.is_death() {
+            self.node.borrow_mut().kill(genome_length);
+            debug_assert!(!self.node.is_alive());
+            debug_assert!(self.node.borrow().ancestry.is_empty());
+        }
     }
 }
 
-pub(crate) struct NodeHeap {
+impl From<PrioritizedNode> for Node {
+    fn from(value: PrioritizedNode) -> Self {
+        value.get()
+    }
+}
+
+pub struct NodeHeap {
     heap: BinaryHeap<PrioritizedNode>,
     in_heap: HashSet<Node>,
 }
 
 impl NodeHeap {
-    pub(crate) fn new() -> Self {
-        Self {
-            heap: BinaryHeap::new(),
-            in_heap: HashSet::new(),
-        }
-    }
-
-    pub fn push(&mut self, node: Node) -> bool {
+    fn push(&mut self, node: Node, node_type: NodeType) -> bool {
         if !self.in_heap.contains(&node) {
             self.in_heap.insert(node.clone());
-            self.heap.push(PrioritizedNode(node));
+            self.heap.push(PrioritizedNode::new(node, node_type));
             true
         } else {
             false
         }
     }
 
-    pub fn pop(&mut self) -> Option<Node> {
+    pub(crate) fn push_parent(&mut self, node: Node) {
+        let _ = self.push(node, NodeType::Parent);
+    }
+
+    pub(crate) fn pop(&mut self) -> Option<PrioritizedNode> {
         match self.heap.pop() {
             Some(x) => {
-                self.in_heap.remove(&x.0);
-                Some(x.get())
+                self.in_heap.remove(&x.node);
+                Some(x)
             }
             None => None,
         }
     }
 
-    #[allow(dead_code)]
+    pub fn new() -> Self {
+        Self {
+            heap: BinaryHeap::new(),
+            in_heap: HashSet::new(),
+        }
+    }
+
     pub fn is_empty(&self) -> bool {
         assert_eq!(self.heap.is_empty(), self.in_heap.is_empty());
         self.heap.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        assert_eq!(self.heap.is_empty(), self.in_heap.is_empty());
+        self.heap.len()
+    }
+
+    pub fn push_birth(&mut self, node: Node) -> Result<(), InlineAncestryError> {
+        if !node.is_alive() {
+            Err(InlineAncestryError::DeadNode)
+        } else {
+            let _ = self.push(node, NodeType::Birth);
+            Ok(())
+        }
+    }
+
+    pub fn push_death(&mut self, node: Node) -> Result<(), InlineAncestryError> {
+        if !node.is_alive() {
+            Err(InlineAncestryError::DeadNode)
+        } else {
+            let _ = self.push(node, NodeType::Death);
+            Ok(())
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.heap.clear();
+        self.in_heap.clear();
+    }
+}
+
+impl Default for NodeHeap {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -80,19 +152,31 @@ mod tests {
         let a = Node::new_alive(0, 1);
         let b = Node::new_alive(0, 2);
 
-        let mut heap = NodeHeap::new();
-        let inserted = heap.push(a.clone());
-        assert!(inserted);
-        let inserted = heap.push(a);
-        assert!(!inserted);
-        let inserted = heap.push(b);
-        assert!(inserted);
+        let mut heap = NodeHeap::default();
+        heap.push_birth(a.clone()).unwrap();
+        heap.push_death(b).unwrap();
 
+        // WARNING: this is a test of internal details!
         let mut birth_times = vec![];
         while let Some(x) = heap.pop() {
-            birth_times.push(x.borrow().birth_time);
+            birth_times.push(x.node.borrow().birth_time);
         }
         assert_eq!(birth_times, vec![2, 1]);
         assert!(heap.is_empty());
+    }
+
+    // WARNING: this is a test of internal details!
+    #[test]
+    fn test_node_type_ordering() {
+        let p = NodeType::Parent;
+        let b = NodeType::Birth;
+        let d = NodeType::Death;
+
+        assert_eq!(p, p);
+        assert_eq!(d, d);
+        assert_eq!(b, b);
+        assert!(p < b);
+        assert!(p < d);
+        assert!(b < d);
     }
 }

--- a/ancestry-inline-simplification/src/propagate_ancestry_changes.rs
+++ b/ancestry-inline-simplification/src/propagate_ancestry_changes.rs
@@ -1,0 +1,21 @@
+use crate::node::Node;
+use crate::node_heap::NodeHeap;
+use crate::InlineAncestryError;
+
+pub fn propagate_ancestry_changes(
+    genome_length: crate::LargeSignedInteger,
+    node_heap: &mut NodeHeap,
+) -> Result<(), InlineAncestryError> {
+    while let Some(mut n) = node_heap.pop() {
+        n.preprocess(genome_length);
+        let mut node = Node::from(n);
+        let changed = node.update_ancestry()?;
+        if changed || node.is_alive() {
+            for parent in node.borrow_mut().parents.iter() {
+                node_heap.push_parent(parent.clone());
+            }
+        }
+    }
+    assert!(node_heap.is_empty());
+    Ok(())
+}


### PR DESCRIPTION
Implement latest from Python protoype:

* process nodes at most 1x
* process births and deaths at the same time.
