### PR TITLE
Ancestry squashing

### DIFF
--- a/ancestry-inline-simplification/src/ancestry_overlapper.rs
+++ b/ancestry-inline-simplification/src/ancestry_overlapper.rs
@@ -23,11 +23,10 @@ impl AncestryOverlapper {
         let n = intersections.len();
         let overlaps = vec![];
 
-        intersections.sort();
         let sorted = intersections.windows(2).all(|w| {
             w[0].left() <= w[1].left() && w[0].left() < w[0].right() && w[1].left() < w[1].right()
         });
-        assert!(sorted);
+        if !sorted { intersections.sort(); }
         // Sentinel -- FIXME: get rid of the need for the dummy Nodes
         intersections.push(AncestryIntersection::new(
             LargeSignedInteger::MAX - 1,

--- a/ancestry-inline-simplification/src/node.rs
+++ b/ancestry-inline-simplification/src/node.rs
@@ -2,6 +2,7 @@ use crate::InlineAncestryError;
 use crate::{
     AncestrySegment, HalfOpenInterval, LargeSignedInteger, NodeFlags, Segment, SignedInteger,
 };
+use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
 use std::rc::Rc;
 use std::{cell::RefCell, ops::Deref};
@@ -32,6 +33,14 @@ pub struct NodeData {
     pub parents: ParentSet,
     pub ancestry: Vec<AncestrySegment>,
     pub children: ChildMap,
+}
+
+impl Debug for Node {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Node")
+            .field("index", &self.borrow().index)
+            .finish()
+    }
 }
 
 impl Deref for Node {

--- a/ancestry-inline-simplification/src/node_heap.rs
+++ b/ancestry-inline-simplification/src/node_heap.rs
@@ -10,6 +10,7 @@ enum NodeType {
     Death,
 }
 
+#[derive(Debug)]
 pub(crate) struct PrioritizedNode {
     node: Node,
     node_type: NodeType,

--- a/ancestry-inline-simplification/src/population.rs
+++ b/ancestry-inline-simplification/src/population.rs
@@ -152,7 +152,7 @@ impl EvolveAncestry for Population {
 
         self.births.clear();
 
-        crate::propagate_ancestry_changes::propagate_ancestry_changes(
+        let _poppped = crate::propagate_ancestry_changes::propagate_ancestry_changes(
             self.genome_length,
             &mut self.node_heap,
         )?;

--- a/ancestry-inline-simplification/src/propagate_ancestry_changes.rs
+++ b/ancestry-inline-simplification/src/propagate_ancestry_changes.rs
@@ -1,21 +1,96 @@
 use crate::node::Node;
 use crate::node_heap::NodeHeap;
+use crate::segments::AncestrySegment;
+use crate::segments::HalfOpenInterval;
 use crate::InlineAncestryError;
 
 pub fn propagate_ancestry_changes(
     genome_length: crate::LargeSignedInteger,
     node_heap: &mut NodeHeap,
-) -> Result<(), InlineAncestryError> {
+) -> Result<i32, InlineAncestryError> {
+    let mut popped = 0;
     while let Some(mut n) = node_heap.pop() {
+        popped += 1;
         n.preprocess(genome_length);
         let mut node = Node::from(n);
+        #[cfg(debug_assertions)]
+        let ancestry = {
+            let mut ancestry = vec![];
+            for i in node.borrow().ancestry.iter() {
+                ancestry.push(i.clone());
+            }
+            ancestry
+        };
+
         let changed = node.update_ancestry()?;
-        if changed || node.is_alive() {
+
+        #[cfg(debug_assertions)]
+        {
+            if changed {
+                //println!("node {}, {}", node.borrow().index, node.is_alive());
+                //println!("{:?}", ancestry);
+                //println!("{} children before", nc);
+                //println!("+++++");
+                //println!("{:?}", node.borrow().ancestry);
+                //println!("{} children after", node.borrow().children.len());
+                //println!("-----");
+                let mut before = vec![];
+                if !ancestry.is_empty() {
+                    before.push(ancestry[0].clone());
+                }
+                for a in ancestry.windows(2) {
+                    //println!("window {:?}", a);
+                    if a[0].child != a[1].child {
+                        before.push(a[1].clone());
+                    } else {
+                        if a[0].segment.right == a[1].segment.left {
+                            match before.last_mut() {
+                                Some(value) => value.segment.right = a[1].segment.left,
+                                None => (),
+                            }
+                        } else {
+                            before.push(a[1].clone());
+                        }
+                    }
+                }
+                let mut after = vec![];
+                //println!("bsquashed {:?}", before);
+                let b = node.borrow();
+                if !b.ancestry.is_empty() {
+                    after.push(b.ancestry[0].clone());
+                }
+                for a in b.ancestry.windows(2) {
+                    //println!("window {:?}", a);
+                    if a[0].child != a[1].child {
+                        after.push(a[1].clone());
+                    } else {
+                        if a[0].segment.right == a[1].segment.left {
+                            match after.last_mut() {
+                                Some(value) => value.segment.right = a[1].segment.left,
+                                None => (),
+                            }
+                        } else {
+                            after.push(a[1].clone());
+                        }
+                    }
+                }
+                //println!("asquashed {:?}", after);
+
+                if before == after && !before.is_empty() {
+                    assert!(false, "{} {}", changed, b.is_alive());
+                }
+
+                //println!("///////");
+            }
+        }
+
+        if changed {
+            //|| node.is_alive() {
             for parent in node.borrow_mut().parents.iter() {
                 node_heap.push_parent(parent.clone());
             }
         }
     }
     assert!(node_heap.is_empty());
-    Ok(())
+    Ok(popped)
 }

--- a/ancestry-inline-simplification/src/segments.rs
+++ b/ancestry-inline-simplification/src/segments.rs
@@ -11,7 +11,7 @@ pub(crate) trait HalfOpenInterval {
     }
 }
 
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Segment {
     pub left: LargeSignedInteger,
     pub right: LargeSignedInteger,
@@ -40,7 +40,7 @@ impl Segment {
     }
 }
 
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AncestrySegment {
     pub segment: Segment,
     pub child: Node,
@@ -55,7 +55,7 @@ impl AncestrySegment {
     }
 }
 
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, Debug, PartialEq)]
 pub(crate) struct AncestryIntersection {
     pub ancestry_segment: AncestrySegment,
     pub mapped_node: Node,

--- a/example.txt
+++ b/example.txt
@@ -1,0 +1,1 @@
+./target/debug/benchmark -N 10 -n 1000 -r 50 dynamic

--- a/run_benchmark.sh
+++ b/run_benchmark.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-N=10000
+N=1000
 nsteps=1000
 nsteps=300
 L=10000


### PR DESCRIPTION
During simplification, failure to squash output ancestry
leads to too much work being done.
